### PR TITLE
Disable echo in [un]link batch scripts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     md5: {{ md5 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,2 +1,4 @@
+@echo off
+
 "%PREFIX%\Scripts\jupyter.exe" nbextensions_configurator enable --sys-prefix
 if errorlevel 1 exit 1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,2 +1,4 @@
+@echo off
+
 "%PREFIX%\Scripts\jupyter.exe" nbextensions_configurator disable --sys-prefix
 if errorlevel 1 exit 1


### PR DESCRIPTION
We've discovered that there is some noise from the commands run in the batch files due to these [un]link batch scripts. It was found through [discussion](https://github.com/conda-forge/ipyparallel-feedstock/pull/6#issuecomment-234967309) that this change would solve that issue.
