### PR TITLE
more aggressive redirection from subshell

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     md5: {{ md5 }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,5 @@
 @echo off
 (
   "%PREFIX%\Scripts\jupyter-nbextensions_configurator.exe" enable --sys-prefix
+  if errorlevel 1 exit 1
 ) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,4 @@
 @echo off
-
-"%PREFIX%\Scripts\jupyter.exe" nbextensions_configurator enable --sys-prefix
-if errorlevel 1 exit 1
+(
+  "%PREFIX%\Scripts\jupyter-nbextensions_configurator.exe" enable --sys-prefix
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,4 @@
-"${PREFIX}/bin/jupyter" nbextensions_configurator enable --sys-prefix
+#!/bin/bash
+{
+  "${PREFIX}/bin/jupyter-nbextensions_configurator" enable --sys-prefix
+} >>"${PREFIX}/.messages.txt" 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,4 +1,5 @@
 @echo off
 (
   "%PREFIX%\Scripts\jupyter-nbextensions_configurator.exe" disable --sys-prefix
+  if errorlevel 1 exit 1
 ) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,4 +1,4 @@
 @echo off
-
-"%PREFIX%\Scripts\jupyter.exe" nbextensions_configurator disable --sys-prefix
-if errorlevel 1 exit 1
+(
+  "%PREFIX%\Scripts\jupyter-nbextensions_configurator.exe" disable --sys-prefix
+) >>"%PREFIX%\.messages.txt" 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,4 @@
-"${PREFIX}/bin/jupyter" nbextensions_configurator disable --sys-prefix
+#!/bin/bash
+{
+  "${PREFIX}/bin/jupyter-nbextensions_configurator" disable --sys-prefix
+} >>"${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
As part of finding the root cause of https://github.com/conda-forge/staged-recipes/pull/1159 (ended up being https://github.com/conda-forge/jupyter_contrib_core-feedstock/pull/1), I cleaned the scripts up to run inside a subshell, which seems to catch "more" output: basically, it doesn't break the progress bar (think of that happening as 1000 `conda whatever --json`s crying). It also let me see the real error, so that's cool.
