### PR TITLE
use pip for installation, instead of python setup.py

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,8 @@ install:
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda update --yes --quiet conda
+    # line below is a temp fix from https://github.com/conda/conda/issues/6527
+    - cmd: conda config --system --add pinned_packages defaults::conda
 
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 1
   script: pip install --no-deps .
+  entry_points:
+    - jupyter-nbextensions_configurator = jupyter_nbextensions_configurator.application:main
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,13 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: pip install --no-deps .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - jupyter_contrib_core >=0.3.2
@@ -26,7 +26,6 @@ requirements:
     - nbconvert
     - notebook >=4.0
     - pyyaml
-    - setuptools
     - tornado
     - traitlets
 


### PR DESCRIPTION
otherwise wrapper scripts don't resolve dependencies correctly.

Fixes #21 